### PR TITLE
Add boost include file to make epos work in Kinetic

### DIFF
--- a/epos_hardware/include/epos_hardware/epos_hardware.h
+++ b/epos_hardware/include/epos_hardware/epos_hardware.h
@@ -7,6 +7,8 @@
 #include <hardware_interface/robot_hw.h>
 #include <transmission_interface/robot_transmissions.h>
 #include <transmission_interface/transmission_interface_loader.h>
+#include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 #include "epos_hardware/utils.h"
 #include "epos_hardware/epos.h"
 #include "epos_hardware/epos_manager.h"


### PR DESCRIPTION
Changes required to make the drivers to work in ROS Kinetic