### PR TITLE
F add homing start service

### DIFF
--- a/epos_hardware/CMakeLists.txt
+++ b/epos_hardware/CMakeLists.txt
@@ -8,6 +8,18 @@ find_package(catkin REQUIRED COMPONENTS
   controller_manager
   roscpp
   diagnostic_updater
+  std_msgs
+  message_generation
+)
+
+add_service_files(
+  FILES
+  StopHoming.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
 )
 
 catkin_package(

--- a/epos_hardware/CMakeLists.txt
+++ b/epos_hardware/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_service_files(
   FILES
   StopHoming.srv
+  StartHoming.srv
 )
 
 generate_messages(

--- a/epos_hardware/include/epos_hardware/epos.h
+++ b/epos_hardware/include/epos_hardware/epos.h
@@ -40,6 +40,7 @@ public:
   void read();
   void write();
   bool stop_homing();
+  bool start_homing();
   std::string name() { return name_; }
   std::string actuator_name() { return actuator_name_; }
   void update_diagnostics();

--- a/epos_hardware/include/epos_hardware/epos.h
+++ b/epos_hardware/include/epos_hardware/epos.h
@@ -25,7 +25,8 @@ class Epos {
 public:
   typedef enum {
     PROFILE_POSITION_MODE = 1,
-    PROFILE_VELOCITY_MODE = 3
+    PROFILE_VELOCITY_MODE = 3,
+    HOMING_MODE = 6
   } OperationMode;
 
   Epos(const std::string& name,
@@ -38,6 +39,7 @@ public:
   bool init();
   void read();
   void write();
+  bool stop_homing();
   std::string name() { return name_; }
   std::string actuator_name() { return actuator_name_; }
   void update_diagnostics();

--- a/epos_hardware/include/epos_hardware/epos_hardware.h
+++ b/epos_hardware/include/epos_hardware/epos_hardware.h
@@ -23,6 +23,7 @@ public:
   void read();
   void write();
   bool stop_homing();
+  bool start_homing();
   void update_diagnostics();
 private:
   hardware_interface::ActuatorStateInterface asi;

--- a/epos_hardware/include/epos_hardware/epos_hardware.h
+++ b/epos_hardware/include/epos_hardware/epos_hardware.h
@@ -22,6 +22,7 @@ public:
   bool init();
   void read();
   void write();
+  bool stop_homing();
   void update_diagnostics();
 private:
   hardware_interface::ActuatorStateInterface asi;

--- a/epos_hardware/include/epos_hardware/epos_hardware.h
+++ b/epos_hardware/include/epos_hardware/epos_hardware.h
@@ -12,6 +12,8 @@
 #include "epos_hardware/utils.h"
 #include "epos_hardware/epos.h"
 #include "epos_hardware/epos_manager.h"
+#include "epos_hardware/StopHoming.h"
+#include "epos_hardware/StartHoming.h"
 
 
 namespace epos_hardware {
@@ -22,8 +24,6 @@ public:
   bool init();
   void read();
   void write();
-  bool stop_homing();
-  bool start_homing();
   void update_diagnostics();
 private:
   hardware_interface::ActuatorStateInterface asi;
@@ -34,6 +34,14 @@ private:
 
   transmission_interface::RobotTransmissions robot_transmissions;
   boost::scoped_ptr<transmission_interface::TransmissionInterfaceLoader> transmission_loader;
+
+  bool stopHomingSrv(epos_hardware::StopHoming::Request &req,
+                     epos_hardware::StopHoming::Response &res);
+
+  bool startHomingSrv(epos_hardware::StartHoming::Request &req,
+                      epos_hardware::StartHoming::Response &res);
+
+  ros::ServiceServer stop_motor_homing, start_motor_homing;
 };
 
 }

--- a/epos_hardware/include/epos_hardware/epos_manager.h
+++ b/epos_hardware/include/epos_hardware/epos_manager.h
@@ -25,6 +25,7 @@ public:
   void read();
   void write();
   bool stop_homing();
+  bool start_homing();
   void update_diagnostics();
   std::vector<boost::shared_ptr<Epos> > motors() { return motors_; };
 private:

--- a/epos_hardware/include/epos_hardware/epos_manager.h
+++ b/epos_hardware/include/epos_hardware/epos_manager.h
@@ -24,6 +24,7 @@ public:
   bool init();
   void read();
   void write();
+  bool stop_homing();
   void update_diagnostics();
   std::vector<boost::shared_ptr<Epos> > motors() { return motors_; };
 private:

--- a/epos_hardware/package.xml
+++ b/epos_hardware/package.xml
@@ -19,12 +19,14 @@
   <build_depend>controller_manager</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>diagnostic_updater</build_depend>
+  <build_depend>message_generation</build_depend>
   <run_depend>epos_library</run_depend>
   <run_depend>hardware_interface</run_depend>
   <run_depend>transmission_interface</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>diagnostic_updater</run_depend>
+  <run_depend>message_runtime</run_depend>
 
   <export>
   </export>

--- a/epos_hardware/src/nodes/epos_hardware_node.cpp
+++ b/epos_hardware/src/nodes/epos_hardware_node.cpp
@@ -3,25 +3,7 @@
 #include "epos_hardware/epos_hardware.h"
 #include <controller_manager/controller_manager.h>
 #include <vector>
-#include "epos_hardware/StopHoming.h"
-#include "epos_hardware/StartHoming.h"
 
-bool stopHoming(epos_hardware::StopHoming::Request  &req,
-    epos_hardware::StopHoming::Response &res, epos_hardware::EposHardware* robot)
-{
-    res.stopped = robot->stop_homing();
-    if(res.stopped == true)
-        return true;
-}
-
-bool startHoming(epos_hardware::StartHoming::Request &req,
-    epos_hardware::StartHoming::Response &res, epos_hardware::EposHardware* robot)
-{
-    res.started = robot->start_homing();
-    if(res.started == true)
-        return true;
-
-}
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "epos_velocity_hardware");
@@ -37,14 +19,6 @@ int main(int argc, char** argv) {
 
   ros::AsyncSpinner spinner(3);
   spinner.start();
-
-  boost::function<bool(epos_hardware::StopHoming::Request & req, epos_hardware::StopHoming::Response & res)>
-  stop_homing_cb = boost::bind(&stopHoming, _1, _2, &robot);
-  boost::function<bool(epos_hardware::StartHoming::Request & req, epos_hardware::StartHoming::Response & res)>
-  start_homing_cb = boost::bind(&startHoming, _1, _2, &robot);
-
-  ros::ServiceServer stop_motor_homing = nh.advertiseService("stop_motor_homing", stop_homing_cb);
-  ros::ServiceServer start_motor_homing = nh.advertiseService("start_motor_homing", start_homing_cb);
 
   ROS_INFO("Initializing Motors");
   if(!robot.init()) {

--- a/epos_hardware/src/nodes/epos_hardware_node.cpp
+++ b/epos_hardware/src/nodes/epos_hardware_node.cpp
@@ -4,6 +4,7 @@
 #include <controller_manager/controller_manager.h>
 #include <vector>
 #include "epos_hardware/StopHoming.h"
+#include "epos_hardware/StartHoming.h"
 
 bool stopHoming(epos_hardware::StopHoming::Request  &req,
     epos_hardware::StopHoming::Response &res, epos_hardware::EposHardware* robot)
@@ -11,6 +12,15 @@ bool stopHoming(epos_hardware::StopHoming::Request  &req,
     res.stopped = robot->stop_homing();
     if(res.stopped == true)
         return true;
+}
+
+bool startHoming(epos_hardware::StartHoming::Request &req,
+    epos_hardware::StartHoming::Response &res, epos_hardware::EposHardware* robot)
+{
+    res.started = robot->start_homing();
+    if(res.started == true)
+        return true;
+
 }
 
 int main(int argc, char** argv) {
@@ -25,13 +35,16 @@ int main(int argc, char** argv) {
   epos_hardware::EposHardware robot(nh, pnh, motor_names);
   controller_manager::ControllerManager cm(&robot, nh);
 
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
 
   boost::function<bool(epos_hardware::StopHoming::Request & req, epos_hardware::StopHoming::Response & res)>
   stop_homing_cb = boost::bind(&stopHoming, _1, _2, &robot);
+  boost::function<bool(epos_hardware::StartHoming::Request & req, epos_hardware::StartHoming::Response & res)>
+  start_homing_cb = boost::bind(&startHoming, _1, _2, &robot);
 
   ros::ServiceServer stop_motor_homing = nh.advertiseService("stop_motor_homing", stop_homing_cb);
+  ros::ServiceServer start_motor_homing = nh.advertiseService("start_motor_homing", start_homing_cb);
 
   ROS_INFO("Initializing Motors");
   if(!robot.init()) {

--- a/epos_hardware/src/util/epos.cpp
+++ b/epos_hardware/src/util/epos.cpp
@@ -495,7 +495,7 @@ bool Epos::init() {
 	    .all_or_none(homing))
         return false;
 
-        int position_raw_init;
+        int position_raw;
         VCS_GetPositionIs(node_handle_->device_handle->ptr, node_handle_->node_id, &position_raw, &error_code);
 
         ROS_INFO_STREAM("Enabling Motor");
@@ -503,7 +503,7 @@ bool Epos::init() {
             return false;
 
         std::cout<<"current pos: "<< position_raw <<std::endl;
-        if(homing == 1 && position_raw_init == 0){
+        if(homing == 1 && position_raw == 0){
             VCS(SetHomingParameter,
 	            homing_acceleration,
 	            speed_switch,

--- a/epos_hardware/src/util/epos.cpp
+++ b/epos_hardware/src/util/epos.cpp
@@ -156,6 +156,7 @@ bool Epos::init() {
     return false;
   }
 
+
   std::string fault_reaction_str;
 #define SET_FAULT_REACTION_OPTION(val)					\
   do {									\
@@ -500,8 +501,7 @@ bool Epos::init() {
 
         int position_raw;
         VCS_GetPositionIs(node_handle_->device_handle->ptr, node_handle_->node_id, &position_raw, &error_code);
-
-        if(homing == 1 && position_raw == 1){
+        if(homing == 1 && position_raw == 0){
             VCS(SetHomingParameter,
 	            homing_acceleration,
 	            speed_switch,

--- a/epos_hardware/src/util/epos.cpp
+++ b/epos_hardware/src/util/epos.cpp
@@ -156,8 +156,6 @@ bool Epos::init() {
     return false;
   }
 
-  //VCS(SetOperationMode, operation_mode_);
-
   std::string fault_reaction_str;
 #define SET_FAULT_REACTION_OPTION(val)					\
   do {									\
@@ -502,7 +500,7 @@ bool Epos::init() {
 
         int position_raw;
         VCS_GetPositionIs(node_handle_->device_handle->ptr, node_handle_->node_id, &position_raw, &error_code);
-        std::cout << "position_raw: " << position_raw << std::endl;
+
         if(homing == 1 && position_raw == 1){
             VCS(SetHomingParameter,
 	            homing_acceleration,
@@ -572,11 +570,6 @@ bool Epos::init() {
     ROS_WARN("No torque constant specified, you can supply one using the 'torque_constant' parameter");
     torque_constant_ = 1.0;
   }
-
-  //ROS_INFO_STREAM("Enabling Motor");
-  //if(!VCS_SetEnableState(node_handle_->device_handle->ptr, node_handle_->node_id, &error_code))
-  // return false;
-
 
     has_init_ = true;
     return true;

--- a/epos_hardware/src/util/epos_hardware.cpp
+++ b/epos_hardware/src/util/epos_hardware.cpp
@@ -100,4 +100,8 @@ void EposHardware::write() {
 bool EposHardware::stop_homing() {
   return epos_manager_.stop_homing();
 }
+
+bool EposHardware::start_homing() {
+  return epos_manager_.start_homing();
+}
 }

--- a/epos_hardware/src/util/epos_hardware.cpp
+++ b/epos_hardware/src/util/epos_hardware.cpp
@@ -97,4 +97,7 @@ void EposHardware::write() {
   epos_manager_.write();
 }
 
+bool EposHardware::stop_homing() {
+  return epos_manager_.stop_homing();
+}
 }

--- a/epos_hardware/src/util/epos_hardware.cpp
+++ b/epos_hardware/src/util/epos_hardware.cpp
@@ -73,6 +73,10 @@ EposHardware::EposHardware(ros::NodeHandle& nh, ros::NodeHandle& pnh, const std:
     }
   }
 
+  // Advertise services
+  stop_motor_homing = nh.advertiseService("stop_motor_homing", &EposHardware::stopHomingSrv, this);
+  start_motor_homing = nh.advertiseService("start_motor_homing", &EposHardware::startHomingSrv, this);
+
 }
 
 bool EposHardware::init() {
@@ -97,11 +101,19 @@ void EposHardware::write() {
   epos_manager_.write();
 }
 
-bool EposHardware::stop_homing() {
-  return epos_manager_.stop_homing();
+bool EposHardware::stopHomingSrv(epos_hardware::StopHoming::Request  &req,
+    epos_hardware::StopHoming::Response &res)
+{
+    res.stopped = epos_manager_.stop_homing();
+    if(res.stopped == true)
+        return true;
 }
 
-bool EposHardware::start_homing() {
-  return epos_manager_.start_homing();
+bool EposHardware::startHomingSrv(epos_hardware::StartHoming::Request &req,
+    epos_hardware::StartHoming::Response &res)
+{
+    res.started = epos_manager_.start_homing();
+    if(res.started == true)
+        return true;
 }
 }

--- a/epos_hardware/src/util/epos_manager.cpp
+++ b/epos_hardware/src/util/epos_manager.cpp
@@ -47,5 +47,16 @@ void EposManager::write() {
   }
 }
 
+bool EposManager::stop_homing(){
+    bool success = true;
+    BOOST_FOREACH(const boost::shared_ptr<Epos>& motor, motors_) {
+        if(!motor->stop_homing()){
+          ROS_ERROR_STREAM("Could not stop motor: " << motor->name());
+          success = false;
+        }
+    }
+    return success;
+}
+
 
 }

--- a/epos_hardware/src/util/epos_manager.cpp
+++ b/epos_hardware/src/util/epos_manager.cpp
@@ -51,12 +51,22 @@ bool EposManager::stop_homing(){
     bool success = true;
     BOOST_FOREACH(const boost::shared_ptr<Epos>& motor, motors_) {
         if(!motor->stop_homing()){
-          ROS_ERROR_STREAM("Could not stop motor: " << motor->name());
+          ROS_ERROR_STREAM("Could not stop homing motor: " << motor->name());
           success = false;
         }
     }
     return success;
 }
 
+bool EposManager::start_homing(){
+    bool success = true;
+    BOOST_FOREACH(const boost::shared_ptr<Epos>& motor, motors_) {
+        if(!motor->start_homing()){
+          ROS_ERROR_STREAM("Could not start homing motor: " << motor->name());
+          success = false;
+        }
+    }
+    return success;
+}
 
 }

--- a/epos_hardware/srv/StartHoming.srv
+++ b/epos_hardware/srv/StartHoming.srv
@@ -1,0 +1,2 @@
+---
+bool started

--- a/epos_hardware/srv/StopHoming.srv
+++ b/epos_hardware/srv/StopHoming.srv
@@ -1,0 +1,3 @@
+bool stop
+---
+bool stopped

--- a/epos_hardware/srv/StopHoming.srv
+++ b/epos_hardware/srv/StopHoming.srv
@@ -1,3 +1,2 @@
-bool stop
 ---
 bool stopped


### PR DESCRIPTION
Two services are implemented that allows to start and interrupt homing procedure.
The implementation requires the user to set up homing parameters from the configuration _yaml_ file.
To start and stop the homing procedure two service calls have been added, namely:
- /start_robot_homing
- /stop_robot_homing