### PR TITLE
Use ros::SteadyTime for calculating update period

### DIFF
--- a/epos_hardware/src/nodes/epos_hardware_node.cpp
+++ b/epos_hardware/src/nodes/epos_hardware_node.cpp
@@ -27,11 +27,12 @@ int main(int argc, char** argv) {
   ROS_INFO("Motors Initialized");
 
   ros::Rate controller_rate(50);
-  ros::Time last = ros::Time::now();
+  ros::SteadyTime last = ros::SteadyTime::now();
   while (ros::ok()) {
     robot.read();
-    ros::Time now = ros::Time::now();
-    cm.update(now, now-last);
+    ros::SteadyTime now = ros::SteadyTime::now();
+    ros::WallDuration period = now-last;
+    cm.update(ros::Time::now(), ros::Duration(period.sec, period.nsec));
     robot.write();
     last = now;
     robot.update_diagnostics();


### PR DESCRIPTION
A monotonic time source should be used for calculating the update period passed into the controller manager. This ensures the period is always accurate, and isn't impacted by time smears or time jumps in the wall time. These irregularities in the wall time are not that uncommon, for example when the system time gets synchronized via NTP. `ros::SteadyTime` ensures these irregularities don't break the controller update calculations.